### PR TITLE
[skip-review] fix: ses: auth config via options

### DIFF
--- a/src/providers/ses/__tests__/adapter.test.ts
+++ b/src/providers/ses/__tests__/adapter.test.ts
@@ -200,4 +200,22 @@ describe("SesNotificationService", () => {
             )
         })
     })
+
+    describe("sesClientConfig", () => {
+        it("should pass sesClientConfig to SESClient", () => {
+            const transporter = newMockTransporter()
+            const service = testService(
+                transporter,
+                {
+                    from: '',
+                },
+                {
+                    sesClientConfig: {
+                        region: "us-east-1",
+                    },
+                }
+            )
+            expect(service).toBeDefined()
+        })
+    })
 })

--- a/src/providers/ses/adapter.ts
+++ b/src/providers/ses/adapter.ts
@@ -30,7 +30,7 @@ export type NodemailerConfig = SafeOmit<SendMailOptions,
     from: string
 }
 
-export type SesClientConfig = CheckOptionalClientConfig<SESClientConfig>
+export type SesClientConfig = NonNullable<CheckOptionalClientConfig<SESClientConfig>[0]>
 
 export type SesNotificationServiceConfig = {
     nodemailerConfig: NodemailerConfig
@@ -51,7 +51,7 @@ export class SesNotificationService extends AbstractNotificationProviderService 
     constructor(
         { logger }: InjectedDependencies,
         options: SesNotificationServiceConfig,
-        sesClient: SESClient = new SESClient(...options?.sesClientConfig ?? []),
+        sesClient: SESClient = new SESClient(options?.sesClientConfig ?? []),
         transporter: Transporter<SentMessageInfo> = nodemailer.createTransport({
             SES: { ses: sesClient, aws: { SendRawEmailCommand } }
         })


### PR DESCRIPTION
previously it failed with `Spread syntax requires ...iterable[Symbol.iterator] to be a function`