### PR TITLE
feat: convert Claude workflows to manual triggers and add commit practices

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,14 +1,20 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request number to review'
+        required: true
+        type: string
+  # pull_request:
+  #   types: [opened, synchronize]
+  #   # Optional: Only run on specific file changes
+  #   # paths:
+  #   #   - "src/**/*.ts"
+  #   #   - "src/**/*.tsx"
+  #   #   - "src/**/*.js"
+  #   #   - "src/**/*.jsx"
 
 jobs:
   claude-review:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,22 +1,28 @@
 name: Claude Code
 
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  issues:
-    types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue or PR number to process'
+        required: false
+        type: string
+      comment_body:
+        description: 'Comment body containing @claude mention'
+        required: false
+        type: string
+  # issue_comment:
+  #   types: [created]
+  # pull_request_review_comment:
+  #   types: [created]
+  # issues:
+  #   types: [opened, assigned]
+  # pull_request_review:
+  #   types: [submitted]
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    # if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.kiro/steering/commit-practices.md
+++ b/.kiro/steering/commit-practices.md
@@ -1,0 +1,81 @@
+# Commit Message Best Practices
+
+This repository follows **Conventional Commits** specification for consistent and semantic commit messages.
+
+## Structure
+```
+<type>(<scope>): <description>
+
+[optional body with detailed explanations]
+```
+
+## Types
+- `feat:` - New features or functionality
+- `fix:` - Bug fixes and corrections
+- `chore:` - Maintenance tasks, dependencies, tooling
+- `docs:` - Documentation updates
+- `test:` - Adding or updating tests
+- `refactor:` - Code refactoring without feature changes
+- `perf:` - Performance improvements
+- `style:` - Code style changes (formatting, etc.)
+- `ci:` - CI/CD pipeline changes
+- `build:` - Build system or external dependencies
+
+## Common Scopes
+- `ci:` - CI/CD workflows and automation
+- `docs:` - Documentation files
+- `adapter:` - Core SES adapter functionality
+- `sandbox:` - SES sandbox mode features
+- `templates:` - Template system components
+- `providers:` - Template provider implementations
+- `release:` - Release automation and versioning
+- `*:` - Multiple areas affected
+
+## Description Guidelines
+- Use imperative mood ("add" not "added" or "adds")
+- Start with lowercase letter
+- No period at the end
+- Keep under 50 characters for the subject line
+- Be specific and descriptive
+
+## Body Guidelines
+- Use bullet points for multiple changes
+- Explain the "what" and "why", not the "how"
+- Reference issues/PRs when relevant
+- Keep lines under 72 characters
+
+## Examples from Repository
+```bash
+# Feature additions
+feat: ci: convert Claude workflows to manual triggers
+feat: *: rearrange template providers into subpackage
+feat: expose everything by default
+
+# Bug fixes
+fix: docs: one more update
+fix: adapter: tidy
+fix: sandbox: cleanup
+fix: s3templates: cleanup the interface
+
+# Breaking changes
+feat!: local template provider gets single object as options
+
+# Maintenance
+chore(release): 1.1.0 [skip ci]
+```
+
+## Breaking Changes
+- Use `!` after type/scope for breaking changes: `feat!:`
+- Explain the breaking change in the body
+- Consider semantic versioning impact
+
+## Special Markers
+- `[skip ci]` - Skip CI pipeline execution
+- `[WIP]` - Work in progress (avoid in main branch)
+
+## Quick Reference
+When committing changes, ask yourself:
+1. What type of change is this?
+2. What area/scope does it affect?
+3. What does this change accomplish?
+4. Is this a breaking change?

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,0 +1,13 @@
+# Product Overview
+
+This is a Medusa notification provider plugin that enables email sending through AWS Simple Email Service (SES). The plugin provides:
+
+- **Email delivery** via AWS SES with Nodemailer integration
+- **Template system** supporting Handlebars templates with JSON schema validation
+- **SES sandbox support** with automatic email verification for development environments
+- **Multiple template providers** (local filesystem and S3)
+- **Attachment support** for email attachments
+
+The plugin is designed as a drop-in notification provider for Medusa v2 e-commerce applications, following Medusa's module provider pattern. It's published as an npm package `@bkosm/medusa-notification-ses` and supports both development (sandbox) and production environments.
+
+Key features include automatic retry mechanisms for unverified email addresses in sandbox mode, template caching for performance, and comprehensive configuration options for AWS SES integration.

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,0 +1,66 @@
+# Project Structure
+
+## Root Level Organization
+```
+├── src/                    # Main source code
+├── examples/app/           # Example Medusa application
+├── integration-tests/      # Integration test suite
+├── dist/                   # Compiled output (generated)
+└── .kiro/                  # Kiro configuration and steering
+```
+
+## Source Code Structure (`src/`)
+```
+src/
+├── providers/ses/          # Main SES provider implementation
+│   ├── adapter.ts          # Core notification service adapter
+│   ├── sandbox.ts          # SES sandbox mode handling
+│   ├── templates.ts        # Template management system
+│   ├── utils.ts            # Utility functions
+│   ├── index.ts            # Module provider export
+│   └── template-providers/ # Template provider implementations
+│       ├── local.ts        # Local filesystem provider
+│       ├── s3.ts           # S3 bucket provider
+│       └── interface.ts    # Provider interface definition
+├── __fixtures__/           # Test fixtures and sample templates
+└── __mocks__/              # Jest mocks
+```
+
+## Key Architectural Patterns
+
+### Module Provider Pattern
+- Main entry point exports Medusa `ModuleProvider`
+- Service classes follow Medusa's dependency injection pattern
+- Configuration through options object
+
+### Template Provider System
+- Pluggable template providers via interface
+- Directory-based template structure:
+  ```
+  template-id/
+  ├── handlebars.template.html  # Handlebars template
+  └── data.schema.json          # JSON schema validation
+  ```
+
+### Testing Structure
+- Unit tests co-located with source files (`.test.ts`)
+- Integration tests in separate directory
+- Mocks and fixtures in dedicated directories
+- SWC transformer for fast test execution
+
+## Example Application (`examples/app/`)
+- Full Medusa v2 application demonstrating plugin usage
+- Docker Compose setup with PostgreSQL
+- Sample email templates and configurations
+- Integration test examples
+
+## Export Structure
+- Main export: `./dist/index.js`
+- Template providers: `./dist/template-providers/index.js`
+- TypeScript declarations included for both exports
+
+## Configuration Files
+- `tsconfig.json` - TypeScript compilation settings
+- `jest.config.js` - Test configuration with SWC
+- `justfile` - Task runner for common operations
+- `.releaserc.json` - Semantic release configuration

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,53 @@
+# Technology Stack
+
+## Core Technologies
+- **TypeScript** - Primary language with strict configuration
+- **Node.js** - Runtime (>=22 for main package, >=20 for examples)
+- **Medusa v2** - E-commerce framework integration
+- **AWS SDK v3** - SES and S3 client libraries
+
+## Key Dependencies
+- **@aws-sdk/client-ses** - AWS SES integration
+- **@aws-sdk/client-s3** - S3 template provider
+- **nodemailer** - Email sending abstraction
+- **handlebars** - Template rendering engine
+- **ajv** - JSON schema validation
+
+## Build System
+- **TypeScript Compiler** - Primary build tool
+- **SWC** - Fast TypeScript/JavaScript transformer for Jest
+- **Jest** - Testing framework with SWC transform
+- **Semantic Release** - Automated versioning and publishing
+
+## Common Commands
+
+### Development
+```bash
+npm run build          # Compile TypeScript to dist/
+npm run watch          # Watch mode compilation
+npm run test           # Unit tests
+npm run test:integration # Integration tests
+```
+
+### CI/CD
+```bash
+just ci                # Run full CI pipeline (test + build)
+just build             # Build only
+just release           # Build and publish with semantic-release
+```
+
+### Example App (Medusa)
+```bash
+# In examples/app/
+npm run dev            # Start Medusa in development
+npm run build          # Build Medusa app
+npm run seed           # Seed database
+npm run start          # Start production server
+```
+
+## Configuration Notes
+- Uses Node16 module resolution
+- Strict TypeScript settings enabled
+- Decorators and metadata support for Medusa compatibility
+- Source maps enabled for debugging
+- Test files and mocks excluded from build output

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "kiroAgent.configureMCP": "Enabled"
+}


### PR DESCRIPTION
## Changes

This PR includes two main improvements:

### 1. Convert Claude GitHub Actions to Manual Triggers
- **claude-code-review.yml**: Changed from automatic PR triggers to  with PR number input
- **claude.yml**: Changed from automatic comment/issue triggers to  with optional inputs
- Original triggers are commented out for easy restoration if needed
- Provides better control over Claude API usage and costs

### 2. Add Commit Message Best Practices Documentation
- Created  with conventional commits guidelines
- Documents repository-specific types, scopes, and examples
- Includes quick reference for consistent commit messaging
- Will be automatically loaded by Kiro for future development

## Benefits
- **Cost Control**: Manual Claude API triggers prevent unexpected usage
- **Consistency**: Documented commit practices ensure uniform git history
- **Developer Experience**: Clear guidelines for contributors

## Usage
Manual workflows can be triggered from the GitHub Actions tab with appro- **claude-code-rmeters.